### PR TITLE
selectable 24 hour clock format

### DIFF
--- a/Info-Orbs/.vscode/settings.json
+++ b/Info-Orbs/.vscode/settings.json
@@ -10,5 +10,6 @@
         "new": "cpp"
     },
     "editor.tabSize": 4,
-    "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 0}"
+    "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 0}",
+    "idf.portWin": "COM3"
 }

--- a/Info-Orbs/lib/config/config.h.template
+++ b/Info-Orbs/lib/config/config.h.template
@@ -128,6 +128,7 @@
 
 #define FORMAT_24_HOUR true
 #define SHOW_AM_PM_INDICATOR false
+#define SHOW_SECOND_TICKS true
 
 #define TIMEZONE_API_KEY "97R9WKDPBLIO"
 #define TIMEZONE_API_URL "http://api.timezonedb.com/v2.1/get-time-zone"

--- a/Info-Orbs/lib/globalTime/globalTime.cpp
+++ b/Info-Orbs/lib/globalTime/globalTime.cpp
@@ -31,11 +31,11 @@ void GlobalTime::updateTime() {
         m_unixEpoch = m_timeClient->getEpochTime();
         m_updateTimer = millis();
         m_minute = minute(m_unixEpoch);
-#if FORMAT_24_HOUR == true
-        m_hour = hour(m_unixEpoch);
-#else
-        m_hour = hourFormat12(m_unixEpoch);
-#endif
+        if (m_format24hour) {
+            m_hour = hour(m_unixEpoch);
+        } else {
+            m_hour = hourFormat12(m_unixEpoch);
+        }
         m_second = second(m_unixEpoch);
 
         m_day = day(m_unixEpoch);
@@ -133,4 +133,13 @@ void GlobalTime::getTimeZoneOffsetFromAPI() {
     } else {
         Serial.println("Failed to get timezone offset from API");
     }
+}
+
+bool GlobalTime::getFormat24Hour() {
+    return m_format24hour;
+}
+
+bool GlobalTime::setFormat24Hour(bool format24hour) {
+    m_format24hour = format24hour;
+    return m_format24hour;
 }

--- a/Info-Orbs/lib/globalTime/globalTime.h
+++ b/Info-Orbs/lib/globalTime/globalTime.h
@@ -26,6 +26,8 @@ class GlobalTime {
     String getTime();
     String getWeekday();
     bool isPM();
+    bool getFormat24Hour();
+    bool setFormat24Hour(bool format24hour);
 
    private:
     GlobalTime();
@@ -50,6 +52,8 @@ class GlobalTime {
 
     const int m_oneSecond{1000};
     int m_updateTimer{0};
+
+    bool m_format24hour{FORMAT_24_HOUR};
 
     void getTimeZoneOffsetFromAPI();
 };

--- a/Info-Orbs/src/widgets/clockWidget.cpp
+++ b/Info-Orbs/src/widgets/clockWidget.cpp
@@ -17,6 +17,8 @@ void ClockWidget::setup() {
 }
 
 void ClockWidget::draw(bool force) {
+    GlobalTime* time = GlobalTime::getInstance();
+    
     if (m_lastDisplay1Didget != m_display1Didget || force) {
         displayDidget(0, m_display1Didget, 7, 5, FOREGROUND_COLOR);
         m_lastDisplay1Didget = m_display1Didget;
@@ -43,6 +45,10 @@ void ClockWidget::draw(bool force) {
         } else {
             displayDidget(2, ":", 7, 5, BG_COLOR, false);
         }
+#if SHOW_SECOND_TICKS == true        
+        displaySeconds(2, m_lastSecondSingle, TFT_BLACK);
+        displaySeconds(2, m_secondSingle, FOREGROUND_COLOR);
+#endif
         m_lastSecondSingle = m_secondSingle;
         if (!FORMAT_24_HOUR && SHOW_AM_PM_INDICATOR) {
             displayAmPm(FOREGROUND_COLOR);
@@ -73,7 +79,11 @@ void ClockWidget::update(bool force) {
 
     if (m_lastHourSingle != m_hourSingle || force) {
         if (m_hourSingle < 10) {
-            m_display1Didget = " ";
+            if (FORMAT_24_HOUR) {
+                m_display1Didget = "0";
+            } else {
+                m_display1Didget = " ";
+            }
         } else {
             m_display1Didget = int(m_hourSingle/10);
         }
@@ -92,7 +102,11 @@ void ClockWidget::update(bool force) {
     }
 }
 
-void ClockWidget::changeMode() {}
+void ClockWidget::changeMode() {
+    GlobalTime* time = GlobalTime::getInstance();
+    time->setFormat24Hour( !time->getFormat24Hour() );
+    draw(true);
+}
 
 void ClockWidget::displayDidget(int displayIndex, const String& didget, int font, int fontSize, uint32_t color, bool shadowing) {
     m_manager.selectScreen(displayIndex);


### PR DESCRIPTION
added property to globalTime to reflect the 24 hour format, initialised from FORMAT_24_HOUR
added new define SHOW_SECOND_TICKS to drive showing second tick marks going around the pulsing dots in the middle display
updated clockWidget change method to toggle 24 hour format